### PR TITLE
Add http POST requests

### DIFF
--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -3,8 +3,10 @@
 #
 #! @Chapter Overview
 #! 
-#! CurlInterface allows http and https URLs to be downloaded from
-#! the internet, using the 'curl' library.
+#! CurlInterface allows a user to interact with http and https 
+#! servers on the internet, using the `curl' library.
+#! Pages can be downloaded from a URL, and http POST requests
+#! can be sent to the URL for processing.
 
 #! @Section Installing curlInterface
 #!
@@ -39,7 +41,7 @@
 
 #! @Section Functions
 #!
-#! curlInterface currently provides a single function:
+#! curlInterface currently provides two simple functions:
 
 #! @Arguments URL[, verifyCert]
 #! @Description
@@ -56,3 +58,23 @@
 #!  in the component 'result'. If 'success' is <K>false</K>, then
 #!  'error' will contain a human-readable error string.
 DeclareGlobalFunction( "DownloadURL" );
+
+#! @Arguments URL, str[, verifyCert]
+#! @Description
+#!  Send an HTTP POST request to a URL on the internet. The argument
+#!  <A>URL</A> should be a string describing an address, and should
+#!  start with either http:// or https://
+#!  The argument <A>str</A> should be a string which will be sent to
+#!  the server as a POST request.
+#!  Setting the optional argument <A>verifyCert</A> to <K>false</K>
+#!  disables verification of HTTPS certificates.
+#!  <A>verifyCert</A> defaults to <K>true</K>.
+#!
+#! @Returns A record describing the result. This record will always
+#!  contain the component 'success', which is a boolean describing
+#!  whether the download was successful.
+#!  If 'success' is <K>true</K>, then the response sent by the 
+#!  server is stored in the component 'result'.
+#!  If 'success' is <K>false</K>, then 'error' will contain a
+#!  human-readable error string.
+DeclareGlobalFunction( "PostURL" );

--- a/gap/curl.gi
+++ b/gap/curl.gi
@@ -18,3 +18,19 @@ function(URL, opt...)
         return rec(success := true, result := ret[2]);
     fi;
 end);
+
+InstallGlobalFunction( "PostURL",
+function(URL, str, opt...)
+    local verifyCert, ret;
+    if Length(opt) > 0 then
+        verifyCert := opt[1];
+    else
+        verifyCert := true;
+    fi;
+    ret := CURL_POST_URL(URL, str, verifyCert);
+    if ret[1] = false then
+        return rec(success := false, error := ret[2]);
+    else
+        return rec(success := true, result := ret[2]);
+    fi;
+end);

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -52,3 +52,62 @@ gap> r.success;
 false
 gap> r.error;
 "Could not resolve host: www.google.cheesebadger"
+
+# Check successful POST requests
+gap> r := PostURL("httpbin.org/post", "field1=true&field2=17");;
+gap> SortedList(RecNames(r));
+[ "result", "success" ]
+gap> r.success;
+true
+gap> PositionSublist(r.result, "\"field1\": \"true\"") <> fail;
+true
+gap> PositionSublist(r.result, "\"field2\": \"17\"") <> fail;  
+true
+gap> PositionSublist(r.result, "field3") <> fail;
+false
+
+# Check POST method not allowed (405)
+gap> r := PostURL("www.google.com", "myfield=42");;
+gap> SortedList(RecNames(r));
+[ "result", "success" ]
+gap> r.success;
+true
+gap> PositionSublist(r.result, "myfield") <> fail;
+false
+gap> PositionSublist(r.result, "405") <> fail;
+true
+
+# Check bad URL with POST
+gap> r := PostURL("https://www.google.cheesebadger", "hello");;
+gap> SortedList(RecNames(r));
+[ "error", "success" ]
+gap> r.success;
+false
+gap> r.error;
+"Could not resolve host: www.google.cheesebadger"
+
+# Check not IsStringRep (url)
+gap> url := List("https://www.google.com", letter -> letter);;
+gap> IsStringRep(url);
+false
+gap> r := DownloadURL(url);;
+gap> SortedList(RecNames(r));
+[ "result", "success" ]
+gap> r.success;
+true
+gap> PositionSublist(r.result, "google") <> fail;
+true
+
+# Check not IsStringRep (post_string)
+gap> post_string := List("animal=tiger&material=cotton", letter -> letter);;
+gap> IsStringRep(post_string);
+false
+gap> r := PostURL("httpbin.org/post", post_string, true);;
+gap> r.success;
+true
+gap> PositionSublist(r.result, "\"animal\": \"tiger\"") <> fail;
+true
+gap> PositionSublist(r.result, "\"material\": \"cotton\"") <> fail;
+true
+gap> PositionSublist(r.result, "lion") <> fail;
+false

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -7,6 +7,23 @@ gap> badURL := ListWithIdenticalEntries(4096,' ');;
 gap> DownloadURL(badURL);
 Error, CURL_URL: <URL> must be less than 4096 chars
 
+# URL too long (Post)
+gap> badURL := ListWithIdenticalEntries(4096,' ');;
+gap> PostURL(badURL, "hello");
+Error, CURL_URL: <URL> must be less than 4096 chars
+
 # URL not a string (Download)
 gap> DownloadURL(42);
 Error, CURL_URL: <URL> must be a string
+
+# URL not a string (Post)
+gap> PostURL(42, "hello");
+Error, CURL_URL: <URL> must be a string
+
+# post_string not a string
+gap> PostURL("httpbin.org/post", 17);                     
+Error, CURL_URL: <post_string> must be a string
+
+# invalid verifyCert
+gap> DownloadURL("https://www.google.com", "maybe verify cert");
+Error, CURL_URL: <verifyCert> must be true or false

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -2,7 +2,11 @@
 # test error handling
 #
 
-# URL too long
+# URL too long (Download)
 gap> badURL := ListWithIdenticalEntries(4096,' ');;
 gap> DownloadURL(badURL);
-Error, ReadURL: <URL> must be less than 4096 chars
+Error, CURL_URL: <URL> must be less than 4096 chars
+
+# URL not a string (Download)
+gap> DownloadURL(42);
+Error, CURL_URL: <URL> must be a string


### PR DESCRIPTION
I want to be able to speak to an HTTP server to interact with a REST database from inside GAP.  At the moment `DownloadURL` retrieves database entries beautifully (using GET requests), but to actually send a new entry to the database I need POST requests.

This PR adds a new method, `PostURL`, which sends a given string to a URL as a POST request.  I've included a couple of tests that show it works, and I've documented the user-facing part.

In C, most of the process of POSTing is the same as GETting, so I've pulled most of `FuncCURL_READ_URL` into a new function `CURL_URL` which is called by both Read and Post.  Hopefully everything I've done seems reasonably sane, but I'm willing to take advice if you don't like the look of something.