### PR TITLE
Refactor package for better flexibility

### DIFF
--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -77,4 +77,17 @@ DeclareGlobalFunction( "DownloadURL" );
 #!  server is stored in the component 'result'.
 #!  If 'success' is <K>false</K>, then 'error' will contain a
 #!  human-readable error string.
-DeclareGlobalFunction( "PostURL" );
+DeclareGlobalFunction( "PostToURL" );
+
+#! @Arguments URL, type, out_string, verifyCert)
+#! @Description
+#!   Send an HTTP request of type <A>type</A> to a URL on the internet.
+#!   <A>URL</A>, <A>type</A>, and <A>out_string</A> should all be strings:
+#!   <A>URL</A> is the URL of the server, <A>type</A> is the type of HTTP
+#!   request (e.g. "GET"), and <A>out_string</A> is the message, if any, to send
+#!   to the server (in requests such as GET this will be ignored).  Finally,
+#!   <A>verifyCert</A> should be a boolean describing whether HTTPS certificates
+#!   should be verified.  Currently only GET and POST requests are supported.
+#!   For convenience, GET requests can be called with <Func Name="DownloadURL"/>
+#!   and POST requests can be called with <Func Name="PostToURL"/>.
+DeclareGlobalFunction( "CurlRequest" );

--- a/gap/curl.gi
+++ b/gap/curl.gi
@@ -3,34 +3,39 @@
 #
 # Implementations
 #
-InstallGlobalFunction( "DownloadURL",
-function(URL, opt...)
-    local ret, verifyCert;
-    if Length(opt) > 0 then
-        verifyCert := opt[1];
-    else
-        verifyCert := true;
+InstallGlobalFunction("CurlRequest",
+function(URL, type, out_string, verifyCert)
+    local ret;
+    if not IsString(URL) then
+        ErrorNoReturn("CurlRequest: <URL> must be a string");
+    elif not IsString(type) then
+        ErrorNoReturn("CurlRequest: <type> must be a string");
+    elif not IsString(out_string) then
+        ErrorNoReturn("CurlRequest: <out_string> must be a string");
+    elif verifyCert <> true and verifyCert <> false then
+        ErrorNoReturn("CurlRequest: <verifyCert> must be true or false");
     fi;
-    ret := CURL_READ_URL(URL, verifyCert);
-    if ret[1] = false then
-        return rec(success := false, error := ret[2]);
-    else
-        return rec(success := true, result := ret[2]);
-    fi;
+    return CURL_REQUEST(URL, type, out_string, verifyCert);
 end);
 
-InstallGlobalFunction( "PostURL",
-function(URL, str, opt...)
+InstallGlobalFunction( "DownloadURL",
+function(URL, opt...)
     local verifyCert, ret;
     if Length(opt) > 0 then
         verifyCert := opt[1];
     else
         verifyCert := true;
     fi;
-    ret := CURL_POST_URL(URL, str, verifyCert);
-    if ret[1] = false then
-        return rec(success := false, error := ret[2]);
+    return CurlRequest(URL, "GET", "", verifyCert);
+end);
+
+InstallGlobalFunction( "PostToURL",
+function(URL, str, opt...)
+    local verifyCert;
+    if Length(opt) > 0 then
+        verifyCert := opt[1];
     else
-        return rec(success := true, result := ret[2]);
+        verifyCert := true;
     fi;
+    return CurlRequest(URL, "POST", str, verifyCert);
 end);

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -54,7 +54,7 @@ gap> r.error;
 "Could not resolve host: www.google.cheesebadger"
 
 # Check successful POST requests
-gap> r := PostURL("httpbin.org/post", "field1=true&field2=17");;
+gap> r := PostToURL("httpbin.org/post", "field1=true&field2=17");;
 gap> SortedList(RecNames(r));
 [ "result", "success" ]
 gap> r.success;
@@ -67,7 +67,7 @@ gap> PositionSublist(r.result, "field3") <> fail;
 false
 
 # Check POST method not allowed (405)
-gap> r := PostURL("www.google.com", "myfield=42");;
+gap> r := PostToURL("www.google.com", "myfield=42");;
 gap> SortedList(RecNames(r));
 [ "result", "success" ]
 gap> r.success;
@@ -78,7 +78,7 @@ gap> PositionSublist(r.result, "405") <> fail;
 true
 
 # Check bad URL with POST
-gap> r := PostURL("https://www.google.cheesebadger", "hello");;
+gap> r := PostToURL("https://www.google.cheesebadger", "hello");;
 gap> SortedList(RecNames(r));
 [ "error", "success" ]
 gap> r.success;
@@ -102,7 +102,7 @@ true
 gap> post_string := List("animal=tiger&material=cotton", letter -> letter);;
 gap> IsStringRep(post_string);
 false
-gap> r := PostURL("httpbin.org/post", post_string, true);;
+gap> r := PostToURL("httpbin.org/post", post_string, true);;
 gap> r.success;
 true
 gap> PositionSublist(r.result, "\"animal\": \"tiger\"") <> fail;
@@ -110,4 +110,15 @@ true
 gap> PositionSublist(r.result, "\"material\": \"cotton\"") <> fail;
 true
 gap> PositionSublist(r.result, "lion") <> fail;
+false
+
+# Check not IsStringRep (request type)
+gap> r := CurlRequest("www.google.com", ['G', 'E', 'T'] , "", true);;
+gap> r.success;
+true
+gap> SortedList(RecNames(r));
+[ "result", "success" ]
+gap> PositionSublist(r.result, "google") <> fail;
+true
+gap> PositionSublist(r.result, "tiger") <> fail;
 false

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -5,25 +5,29 @@
 # URL too long (Download)
 gap> badURL := ListWithIdenticalEntries(4096,' ');;
 gap> DownloadURL(badURL);
-Error, CURL_URL: <URL> must be less than 4096 chars
+Error, CURL_REQUEST: <URL> must be less than 4096 chars
 
 # URL too long (Post)
 gap> badURL := ListWithIdenticalEntries(4096,' ');;
-gap> PostURL(badURL, "hello");
-Error, CURL_URL: <URL> must be less than 4096 chars
+gap> PostToURL(badURL, "hello");
+Error, CURL_REQUEST: <URL> must be less than 4096 chars
 
 # URL not a string (Download)
 gap> DownloadURL(42);
-Error, CURL_URL: <URL> must be a string
+Error, CurlRequest: <URL> must be a string
 
 # URL not a string (Post)
-gap> PostURL(42, "hello");
-Error, CURL_URL: <URL> must be a string
+gap> PostToURL(42, "hello");
+Error, CurlRequest: <URL> must be a string
+
+# request type not a string
+gap> CurlRequest("www.google.com", 637, "hello", true);
+Error, CurlRequest: <type> must be a string
 
 # post_string not a string
-gap> PostURL("httpbin.org/post", 17);                     
-Error, CURL_URL: <post_string> must be a string
+gap> PostToURL("httpbin.org/post", 17);                     
+Error, CurlRequest: <out_string> must be a string
 
 # invalid verifyCert
 gap> DownloadURL("https://www.google.com", "maybe verify cert");
-Error, CURL_URL: <verifyCert> must be true or false
+Error, CurlRequest: <verifyCert> must be true or false


### PR DESCRIPTION
This package was only really designed for GET requests to download from URLs on
the internet.  Since then, POST requests have been added, but before adding
support for more requests (personally I'd like DELETE, HEAD and OPTIONS) the
code could do with a bit of reorganising.  This PR reorganises the code to make
a lot of it more general, so that we can add more functionality in the future.

On the GAP level, we have a new function `CurlRequest` which is a single point
of entry to the C level.  Parameters are mostly checked in here, rather than on
the C level (just to make things a bit cleaner), and there's a parameter called
`type` which denotes what sort of request we're taking.  `DownloadURL` and
`PostToURL` call this function with `type` arguments of `GET` and `POST`
respectively.  `PostToURL` is a new, more sensible name for `PostURL`.

On the C level, I've done away with `CURL_READ_URL` and `CURL_POST_URL` in
favour of the single GAP-visible function `CURL_REQUEST` (renamed from the
slightly non-obvious `CURL_URL`).  This takes all needed arguments, including
the string `type_string` ("GET" or whatever).  It seems a good idea just to use
strings here instead of the existing enum, since passing one extra string around
per HTTP request should have negligible performance impact, and it's more
flexible as we come up with more requests to support (including custom
requests).  Finally, `CURL_REQUEST` now creates and returns a record in the
first place, rather than returning a list only to be turned into a record on the
GAP level.

From the outside, the behaviour of existing functions hasn't changed at all -
except a few error messages, andthe renaming of `PostURL` to `PostToURL`.
