### PR TITLE
Avoid single backtick in AutoDoc comment

### DIFF
--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -4,7 +4,7 @@
 #! @Chapter Overview
 #!
 #! CurlInterface allows a user to interact with http and https
-#! servers on the internet, using the `curl' library.
+#! servers on the internet, using the 'curl' library.
 #! Pages can be downloaded from a URL, and http POST requests
 #! can be sent to the URL for processing.
 


### PR DESCRIPTION
Future AutoDoc versions will support backticks to indicate code spans,
just as in Markdown.

See https://github.com/gap-packages/AutoDoc/pull/187