### PR TITLE
Set license to GPL 2 or later

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -4,7 +4,7 @@ Copyright (C) by Chris Jefferson & Michael Torpey
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
+the Free Software Foundation, either version 2 of the License, or
 (at your option) any later version.
 
 This program is distributed in the hope that it will be useful,

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -12,6 +12,7 @@ PackageName := "curlInterface",
 Subtitle := "Simple Web Access",
 Version := "2.1.1",
 Date := "26/10/2018", # dd/mm/yyyy format
+License := "GPL-2.0-or-later",
 
 Persons := [
   rec(


### PR DESCRIPTION
The LICENSE file said "GPL 3 or later", but the file GPL contains
GPL 2. I am assuming it was a typo in the LICENSE file, and that
the intent was to match the license of GAP.

Also add License field to PackageInfo.g

That said, if you really meant it, of course that's also fine, then the License field should still be added (and the file GPL replaced with the GPL v3).