### PR TITLE
Make new build system more robust

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -40,11 +40,13 @@ gen/pkgconfig.h: gen/pkgconfig.h.stamp
 
 gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
 	@rm -f $@
+	@mkdir -p $(@D)
 	./config.status gen/pkgconfig.h
 	echo > $@
 
 gen/pkgconfig.h.in: $(configure_deps)
 	@if command -v autoheader >/dev/null 2>&1 ; then \
+	   mkdir -p $(@D) ; \
 	   echo "running autoheader" ; \
 	   autoheader ; \
 	   rm -f gen/pkgconfig.h.stamp ; \
@@ -52,3 +54,5 @@ gen/pkgconfig.h.in: $(configure_deps)
 	   echo "autoheader not available, proceeding with stale config.h" ; \
 	 fi
 	touch $@
+
+$(KEXT_OBJS): gen/pkgconfig.h

--- a/autogen.sh
+++ b/autogen.sh
@@ -2,5 +2,6 @@
 #
 # Regenerate configure from configure.ac. Requires GNU autoconf.
 set -ex
+mkdir -p gen
 autoconf -Wall -f
 autoheader -Wall -f


### PR DESCRIPTION
In particular, restore the gen directory if missing (e.g. `make clean`
removes it), and also make sure pkgconfig.h is regenerated if necessary.