### PR TITLE
Change #include "src/compiled.h" to just "compiled.h"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,25 +6,28 @@ branches:
 
 addons:
   apt_packages:
+    - libcurl4-openssl-dev
     - libgmp-dev
     - libreadline-dev
     - zlib1g-dev
 
 matrix:
   include:
-    - env: GAPBRANCH="stable-4.9"
-    - env: CFLAGS="-O2" CC=clang CXX=clang++
+    - env: GAPBRANCH=master
+    - env: GAPBRANCH=stable-4.11
+    - env: GAPBRANCH=stable-4.10
+    - env: GAPBRANCH=stable-4.9
+    - env: GAPBRANCH=master CFLAGS="-O2" CC=clang CXX=clang++
       compiler: clang
-    - env: CFLAGS="-O2"
+    - env: GAPBRANCH=master CFLAGS="-O2" GAP_CONFIGFLAGS="--enable-checking"
       compiler: gcc
-    - env: CFLAGS="-O2" GAP_CONFIGFLAGS="--enable-checking"
-      compiler: gcc
-    - env: ABI=32
+    - env: GAPBRANCH=master ABI=32
       addons:
         apt_packages:
           - libcurl4-openssl-dev:i386
           - libgmp-dev:i386
           - libreadline-dev:i386
+          - zlib1g-dev:i386
           - gcc-multilib
           - g++-multilib
 

--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -37,6 +37,12 @@
 # read GAP's build settings
 include $(GAPPATH)/sysinfo.gap
 
+# hack to support GAP = 4.9
+ifndef GAP_KERNEL_MAJOR_VERSION
+  KEXT_CFLAGS += -I$(GAP_LIB_DIR)/src
+  KEXT_CXXFLAGS += -I$(GAP_LIB_DIR)/src
+endif
+
 # various derived settings
 KEXT_BINARCHDIR = bin/$(GAParch)
 KEXT_SO = $(KEXT_BINARCHDIR)/$(KEXT_NAME).so

--- a/m4/find_gap.m4
+++ b/m4/find_gap.m4
@@ -18,8 +18,7 @@ AC_DEFUN([FIND_GAP],
   AC_MSG_CHECKING([for GAP root directory])
   GAPROOT="../.."
 
-  #Allow the user to specify the location of GAP
-  #
+  # Allow the user to specify the location of GAP
   AC_ARG_WITH(gaproot,
     [AS_HELP_STRING([--with-gaproot=<path>], [specify root of GAP installation])],
     [GAPROOT="$withval"])
@@ -72,65 +71,20 @@ AC_DEFUN([FIND_GAP],
     AC_MSG_ERROR([Unable to find plausible GAParch information.])
   fi
 
-
-  AC_MSG_CHECKING([for GAP >= 4.9])
-  # test if this GAP >= 4.9
-  if test "x$GAP_CPPFLAGS" != x; then
-    AC_MSG_RESULT([yes])
-  else
-    AC_MSG_RESULT([no])
-    #####################################
-    # Now check for the GAP header files
-
-    bad=0
-    AC_MSG_CHECKING([for GAP include files])
-    if test -r $GAPROOT/src/compiled.h; then
-      AC_MSG_RESULT([$GAPROOT/src/compiled.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-    AC_MSG_CHECKING([for GAP config.h])
-    if test -r $GAPROOT/bin/$GAPARCH/config.h; then
-      AC_MSG_RESULT([$GAPROOT/bin/$GAPARCH/config.h])
-    else
-      AC_MSG_RESULT([Not found])
-      bad=1
-    fi
-
-    if test "x$bad" = "x1"; then
-      echo ""
-      echo "********************************************************************"
-      echo "  ERROR"
-      echo ""
-      echo "  Failed to find the GAP source header files in src/ and"
-      echo "  GAP's config.h in the architecture dependend directory"
-      echo ""
-      echo "  The kernel build process expects to find the normal GAP "
-      echo "  root directory structure as it is after building GAP itself, and"
-      echo "  in particular the files"
-      echo "      <gaproot>/sysinfo.gap"
-      echo "      <gaproot>/src/<includes>"
-      echo "  and <gaproot>/bin/<architecture>/bin/config.h."
-      echo "  Please make sure that your GAP root directory structure"
-      echo "  conforms to this layout, or give the correct GAP root using"
-      echo "  --with-gaproot=<path>"
-      echo "********************************************************************"
-      echo ""
-      AC_MSG_ERROR([Unable to find GAP include files in /src subdirectory])
-    fi
-
-    ARCHPATH=$GAPROOT/bin/$GAPARCH
-    GAP_CPPFLAGS="-I$GAPROOT -iquote $GAPROOT/src -I$ARCHPATH"
-
-    AC_MSG_CHECKING([for GAP's gmp.h location])
-    if test -r "$ARCHPATH/extern/gmp/include/gmp.h"; then
-      GAP_CPPFLAGS="$GAP_CPPFLAGS -I$ARCHPATH/extern/gmp/include"
-      AC_MSG_RESULT([$ARCHPATH/extern/gmp/include/gmp.h])
-    else
-      AC_MSG_RESULT([not found, GAP was compiled without its own GMP])
-    fi
+  # require GAP >= 4.9
+  if test "x$GAP_CPPFLAGS" = x; then
+    echo ""
+    echo "********************************************************************"
+    echo "  ERROR"
+    echo ""
+    echo "  This version of GAP is too old and not supported by this package."
+    echo "********************************************************************"
+    echo ""
+    AC_MSG_ERROR([No GAP_CPPFLAGS is given])
   fi
+
+  # compatibility with GAP 4.9 (not needed in GAP >= 4.10)
+  GAP_CPPFLAGS="$GAP_CPPFLAGS -I${GAP_LIB_DIR}/src"
 
   AC_SUBST(GAPARCH)
   AC_SUBST(GAPROOT)

--- a/src/curl.c
+++ b/src/curl.c
@@ -2,7 +2,7 @@
 // curlInterface: Simple Web Access
 //
 
-#include "src/compiled.h" // GAP headers
+#include "compiled.h" // GAP headers
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
This will allow future GAP versions to simplify their GAP_CPPFLAGS,
which currently need to contain `-I$(abs_srcdir)` just to support this
old use case. Also, this in turn makes it easier to have package
compatible with future installed version of GAP, which have headers in
PREFIX/include/gap/ so there is no `src` there (unless downstream
packagers jump through hoops to ensure that, e.g. by adding a special
symlink).

Note: we could also #include "gap_all.h" but that would require GAP >= 4.11.