### PR TITLE
configure.ac: AC_CONFIG_HEADER -> AC_CONFIG_HEADERS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl ##
 AC_PREREQ([2.68])
 AC_INIT([curlInterface], [GAP package])
 AC_CONFIG_SRCDIR([src/curl.c])
-AC_CONFIG_HEADER([gen/pkgconfig.h])
+AC_CONFIG_HEADERS([gen/pkgconfig.h])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/find_gap.m4])
 m4_include([m4/libcurl.m4])


### PR DESCRIPTION
This still works in autoconf 2.69 (the most widespread version these days)
but also avoids obsolescence warnings with autoconf >= 2.70.