### PR TITLE
CI: Ensure code coverage reporting will work in February 2022 and beyond

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,7 +41,9 @@ jobs:
       - uses: gap-actions/build-pkg@v1
         with:
           ABI: ${{ matrix.ABI }}
-      - uses: gap-actions/run-pkg-tests@v1
+      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v2
 
   # The documentation job
   manual:


### PR DESCRIPTION
See https://github.com/gap-actions/process-coverage/issues/10
