### PR TITLE
Make basic tests more robust.

### DIFF
--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -146,14 +146,14 @@ false
 gap> r := DeleteURL("https://www.google.com");;
 gap> r.success;
 true
-gap> PositionSublist(r.result, "405") <> fail;
+gap> PositionSublist(r.result, "405 ") <> fail;
 true
 gap> PositionSublist(r.result, "tiger") <> fail;
 false
 gap> r := DeleteURL("www.httpbin.org/delete");;
 gap> r.success;
 true
-gap> PositionSublist(r.result, "405") <> fail;
+gap> PositionSublist(r.result, "405 ") <> fail;
 false
 
 # Check verbose requests don't break anything (we can't catch the output here)
@@ -162,7 +162,7 @@ gap> r.success;
 true
 gap> PositionSublist(r.result, "httpbin") <> fail;
 true
-gap> PositionSublist(r.result, "404") <> fail;
+gap> PositionSublist(r.result, "404 ") <> fail;
 false
 
 # Follow redirects
@@ -176,5 +176,5 @@ true
 gap> r := DownloadURL(url, rec(followRedirect := false));;
 gap> PositionSublist(r.result, "GitHub Pages") <> fail;
 false
-gap> PositionSublist(r.result, "301") <> fail;
+gap> PositionSublist(r.result, "301 ") <> fail;
 true


### PR DESCRIPTION
In the daily CI of the PackageDistro repository, curlInterface
occasionally fails its tests. I believe this is because of the "dumb"
check for the result not containing a certain status code, e.g. 404.

Now, here is a typical result:

    {
      "args": {},
      "headers": {
        "Accept": "*/*",
        "Host": "www.httpbin.org",
        "User-Agent": "curlInterface/GAP package",
        "X-Amzn-Trace-Id": "Root=1-62f4fc1e-00401ff3692cd43d1a2234a5"
      },
      "origin": "131.246.132.154",
      "url": "http://www.httpbin.org/get"
    }

Note the hex string associated to the "X-Amzn-Trace-Id" key... And note
how in my example it actually contains "401" as a substring. Clearly
it can easily also contain "404". I believe this is why the curlInterface
tests sometimes fail.

As a workaround, just search for "404 " instead of "404". It won't match
this, but when we see a genuine 404 error page, it will contain a string
like "404 Not Found" or so.
