### PR TITLE
add option `failOnError`

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,9 @@
 This file describes changes in the curlInterface package.
 
+X.Y.Z (YYYY-MM-DD)
+  - Add option failOnError which treats 4xx status codes such as
+    "404 page not found" as errors in CurlRequest, DownloadURL etc.
+
 2.2.3 (2022-08-15)
   - Make test suite more robust
   - Tweak build system some more

--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -118,11 +118,22 @@ DeclareGlobalFunction("DeleteURL");
 #!   record specifying additional options for the request.  The following
 #!   options are supported:
 #!     * <C>verifyCert</C>: a boolean describing whether to verify HTTPS
-#!       certificates (default <K>true</K>);
+#!       certificates
+#!       (corresponds to the curl options <C>CURLOPT_SSL_VERIFYPEER</C>
+#!       and <C>CURLOPT_SSL_VERIFYHOST</C>,
+#!       the default is <K>true</K> for both);
 #!     * <C>verbose</C>: a boolean describing whether to print extra information
-#!       to the screen (default <K>false</K>);
+#!       to the screen
+#!       (corresponds to the curl option <C>CURLOPT_VERBOSE</C>,
+#!       the default is <K>false</K>);
 #!     * <C>followRedirect</C>: a boolean describing whether to follow
-#!       redirection to another URL (default <K>true</K>).
+#!       redirection to another URL
+#!       (corresponds to the curl option <C>CURLOPT_FOLLOWLOCATION</C>,
+#!       the default is <K>true</K>);
+#!     * <C>failOnError</C>: a boolean describing whether to regard
+#!       404 (and other 4xx) status codes as error
+#!       (corresponds to the curl option <C>CURLOPT_FAILONERROR</C>,
+#!       the default is <K>false</K>).
 #!
 #!   As output, this function returns a record containing some of the following
 #!   components, which describe the outcome of the request:

--- a/gap/curl.gi
+++ b/gap/curl.gi
@@ -8,7 +8,8 @@ function(URL, type, out_string, opts...)
     local r, rnam;
 
     # Get options
-    r := rec(verifyCert := true, verbose := false, followRedirect := true);
+    r := rec(verifyCert := true, verbose := false, followRedirect := true,
+             failOnError:= false);
     if Length(opts) = 1 then
         if not IsRecord(opts[1]) then
             ErrorNoReturn("CurlRequest: <opts> must be a record");
@@ -29,7 +30,7 @@ function(URL, type, out_string, opts...)
     elif not IsString(out_string) then
         ErrorNoReturn("CurlRequest: <out_string> must be a string");
     fi;
-    for rnam in ["verifyCert", "verbose", "followRedirect"] do
+    for rnam in ["verifyCert", "verbose", "followRedirect", "failOnError"] do
         if r.(rnam) <> true and r.(rnam) <> false then
             ErrorNoReturn("CurlRequest: <opts>.", rnam,
                           " must be true or false");
@@ -39,7 +40,8 @@ function(URL, type, out_string, opts...)
     return CURL_REQUEST(URL, type, out_string,
                         r.verifyCert,
                         r.verbose,
-                        r.followRedirect);
+                        r.followRedirect,
+                        r.failOnError);
 end);
 
 InstallGlobalFunction("DownloadURL",

--- a/src/curl.c
+++ b/src/curl.c
@@ -32,13 +32,7 @@ size_t write_string(void * ptr, size_t size, size_t nmemb, Obj buf)
     return size * nmemb;
 }
 
-Obj FuncCURL_REQUEST(Obj self,
-                     Obj URL,
-                     Obj type,
-                     Obj out_string,
-                     Obj verifyCert,
-                     Obj verbose,
-                     Obj followRedirect)
+Obj FuncCURL_REQUEST(Obj self, Obj input_list)
 {
     CURL *     curl;
     CURLcode   res;
@@ -48,14 +42,20 @@ Obj FuncCURL_REQUEST(Obj self,
     char       urlbuf[4096] = { 0 };
     char *     typebuf = NULL;
 
+    const int n = LEN_PLIST(input_list);
+    GAP_ASSERT(n == 7);    // paranoia check, GAP enforces this
+
+    Obj URL = ELM_PLIST(input_list, 1);
     if (!IS_STRING_REP(URL)) {
         URL = CopyToStringRep(URL);
     }
 
+    Obj type = ELM_PLIST(input_list, 2);
     if (!IS_STRING_REP(type)) {
         type = CopyToStringRep(type);
     }
 
+    Obj out_string = ELM_PLIST(input_list, 3);
     if (!IS_STRING_REP(out_string)) {
         out_string = CopyToStringRep(out_string);
     }
@@ -86,11 +86,19 @@ Obj FuncCURL_REQUEST(Obj self,
         curl_easy_setopt(curl, CURLOPT_TCP_NODELAY, 1L);
         curl_easy_setopt(curl, CURLOPT_USERAGENT, "curlInterface/GAP package");
 
+        Obj verifyCert = ELM_PLIST(input_list, 4);
+        Obj verbose = ELM_PLIST(input_list, 5);
+        Obj followRedirect = ELM_PLIST(input_list, 6);
+        Obj failOnError = ELM_PLIST(input_list, 7);
+
         if (verbose == True)
             curl_easy_setopt(curl, CURLOPT_VERBOSE, 1L);
 
         if (followRedirect == True)
             curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
+
+        if (failOnError == True)
+            curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
 
         if (strcmp(CONST_CSTR_STRING(type), "GET") == 0) {
             // simply download from the URL
@@ -177,8 +185,8 @@ Obj FuncCURL_REQUEST(Obj self,
 
 // Table of functions to export
 static StructGVarFunc GVarFuncs[] = {
-    GVAR_FUNC(CURL_REQUEST, 6,
-              "url, type, out_string, verifyCert, verbose, followRedirect"),
+    GVAR_FUNC(CURL_REQUEST, 7,
+              "url, type, out_string, verifyCert, verbose, followRedirect, failOnError"),
     { 0 }
 };
 

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -54,6 +54,19 @@ false
 gap> PositionSublist(r.error, "Could not resolve host") <> fail;
 true
 
+# Check another bad URL
+gap> r := DownloadURL("https://www.gap-system.org/Packages/curlInterface.x");;
+gap> r.success;
+true
+gap> PositionSublist(r.result, "URL was not found") <> fail;
+true
+gap> r := DownloadURL("https://www.gap-system.org/Packages/curlInterface.x",
+>           rec(failOnError:= true));;
+gap> r.success;
+false
+gap> PositionSublist(r.error, "404") <> fail;
+true
+
 # Check successful POST requests
 gap> r := PostToURL("httpbin.org/post", "field1=true&field2=17");;
 gap> SortedList(RecNames(r));

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -40,6 +40,10 @@ Error, CurlRequest: <opts>.verbose must be true or false
 gap> DownloadURL("https://www.google.com", rec(followRedirect := "always"));
 Error, CurlRequest: <opts>.followRedirect must be true or false
 
+# invalid failOnError
+gap> DownloadURL("https://www.google.com", rec(failOnError := "yes"));
+Error, CurlRequest: <opts>.failOnError must be true or false
+
 # invalid opts
 gap> DownloadURL("https://www.google.com", "please verify the cert");
 Error, CurlRequest: <opts> must be a record
@@ -47,3 +51,7 @@ Error, CurlRequest: <opts> must be a record
 # too many arguments
 gap> CurlRequest("www.google.com", "GET", "", rec(verifyCert := true), 3, true);
 Error, CurlRequest: usage: requires 3 or 4 arguments, but 6 were given
+
+# number of arguments
+gap> CURL_REQUEST();
+Error, Function: number of arguments must be 7 (not 0)


### PR DESCRIPTION
The kernel function `CURL_REQUEST` now expects also the flag `failOnError` (corresponding to `CURLOPT_FAILONERROR`), and the GAP function `CurlRequest` sets this flag (default `false`).

The documentation of `CurlRequest` mentions this new option, and lists for all supported options to which curl options they correspond.

This pull request is motivated by gap-packages/utils/pull/48.