### PR TITLE
Move pkgconfig.h.in from gen to src

### DIFF
--- a/Makefile.gappkg
+++ b/Makefile.gappkg
@@ -193,14 +193,14 @@ gen/pkgconfig.h: gen/pkgconfig.h.stamp
 	@if test ! -f $@; then rm -f $<; else :; fi
 	@if test ! -f $@; then $(MAKE) $<; else :; fi
 
-gen/pkgconfig.h.stamp: gen/pkgconfig.h.in config.status
+gen/pkgconfig.h.stamp: src/pkgconfig.h.in config.status
 	@rm -f $@
 	@mkdir -p $(@D)
 	./config.status gen/pkgconfig.h
 	echo > $@
 
 ifneq ($(MAINTAINER_MODE),no)
-gen/pkgconfig.h.in: $(configure_deps)
+src/pkgconfig.h.in: $(configure_deps)
 	@if command -v autoheader >/dev/null 2>&1 ; then \
 	   mkdir -p $(@D) ; \
 	   echo "running autoheader" ; \

--- a/configure.ac
+++ b/configure.ac
@@ -11,7 +11,7 @@ dnl ##
 AC_PREREQ([2.68])
 AC_INIT([curlInterface], [GAP package])
 AC_CONFIG_SRCDIR([src/curl.c])
-AC_CONFIG_HEADERS([gen/pkgconfig.h])
+AC_CONFIG_HEADERS([gen/pkgconfig.h:src/pkgconfig.h.in])
 AC_CONFIG_MACRO_DIR([m4])
 m4_include([m4/find_gap.m4])
 m4_include([m4/libcurl.m4])


### PR DESCRIPTION
The `gen` directory is for things that are created by `make` and it is deleted by `make clean`. But `pkgconfig.h.in` is *not* generated by `make`. So it does not belong into `src` but rather into `gen`.

Unfortunately GAP's `BuildPackages.sh` script runs `make clean` before `make`, which triggered this bug.