### PR TITLE
Consistently use `httpbun.com` in tests and examples

### DIFF
--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -75,7 +75,7 @@ DeclareGlobalFunction("DownloadURL");
 #!   <Ref Func="CurlRequest"/>.
 #!
 #! @BeginExample
-#! gap> r := PostToURL("www.httpbin.org/post", "animal=tiger");;
+#! gap> r := PostToURL("httpbun.com/post", "animal=tiger");;
 #! gap> r.success;
 #! true
 #! gap> r.result{[51..100]};
@@ -160,7 +160,7 @@ DeclareGlobalFunction("DeleteURL");
 #! >                     "",
 #! >                     rec(verifyCert := false));
 #! rec( result := "", success := true )
-#! gap> r := CurlRequest("www.httpbin.org/post", "POST", "animal=tiger");;
+#! gap> r := CurlRequest("httpbun.com/post", "POST", "animal=tiger");;
 #! gap> r.success;
 #! true
 #! gap> r.result{[51..100]};

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -163,14 +163,14 @@ gap> PositionSublist(r.result, "405 ") <> fail;
 true
 gap> PositionSublist(r.result, "tiger") <> fail;
 false
-gap> r := DeleteURL("www.httpbun.com/delete");;
+gap> r := DeleteURL("httpbun.com/delete");;
 gap> r.success;
 true
 gap> PositionSublist(r.result, "405 ") <> fail;
 false
 
 # Check verbose requests don't break anything (we can't catch the output here)
-gap> r := DownloadURL("http://www.httpbun.com/get", rec(verbose := true));;
+gap> r := DownloadURL("httpbun.com/get", rec(verbose := true));;
 gap> r.success;
 true
 gap> PositionSublist(r.result, "httpbin") <> fail;

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -173,7 +173,7 @@ false
 gap> r := DownloadURL("httpbun.com/get", rec(verbose := true));;
 gap> r.success;
 true
-gap> PositionSublist(r.result, "httpbin") <> fail;
+gap> PositionSublist(r.result, "httpbun") <> fail;
 true
 
 #gap> PositionSublist(r.result, "404 ") <> fail;

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -25,7 +25,7 @@ gap> CurlRequest("www.google.com", 637, "hello", rec(verifyCert := true));
 Error, CurlRequest: <type> must be a string
 
 # post_string not a string
-gap> PostToURL("httpbin.org/post", 17);
+gap> PostToURL("httpbun.com/post", 17);
 Error, CurlRequest: <out_string> must be a string
 
 # invalid verifyCert


### PR DESCRIPTION
It seems that `www.httpbun.com` no longer responds to any requests, while `httpbun.com` does.

This results in the following error in CI, found e.g. in the PackageDistro tests (https://github.com/gap-system/PackageDistro/actions/runs/15481482337/job/43588283497#step:9:42) as well as in GAP.jl (https://github.com/oscar-system/GAP.jl/actions/runs/15434809666/job/43439050835#step:8:10). 
```
testing: /home/runner/gap/pkg/curlInterface-2.4.0/tst/basic.tst
########> Diff in /home/runner/gap/pkg/curlInterface-2.4.0/tst/basic.tst:
167
# Input is:
r.success;
# Expected output:
true
# But found:
false
########
########> Diff in /home/runner/gap/pkg/curlInterface-2.4.0/tst/basic.tst:
169
# Input is:
PositionSublist(r.result, "405 ") <> fail;
# Expected output:
false
# But found:
Error, Record Element: '<rec>.result' must have an assigned value
########
* Could not resolve host: www.httpbun.com
* Closing connection
########> Diff in /home/runner/gap/pkg/curlInterface-2.4.0/tst/basic.tst:
174
# Input is:
r.success;
# Expected output:
true
# But found:
false
########
########> Diff in /home/runner/gap/pkg/curlInterface-2.4.0/tst/basic.tst:
176
# Input is:
PositionSublist(r.result, "httpbin") <> fail;
# Expected output:
true
# But found:
Error, Record Element: '<rec>.result' must have an assigned value
########
      21 ms (0 ms GC) and 375KB allocated for basic.tst
testing: /home/runner/gap/pkg/curlInterface-2.4.0/tst/errors.tst
       1 ms (0 ms GC) and 95.0KB allocated for errors.tst
-----------------------------------
total        22 ms (0 ms GC) and [47](https://github.com/gap-system/PackageDistro/actions/runs/15481482337/job/43588283497#step:9:48)0KB allocated
              4 failures in 1 of 2 files
```

Furthermore, this also changes some occurrences of `httpbin.org` to `httpbun.com` that were missed in https://github.com/gap-packages/curlInterface/pull/49.

cc @fingolfin 