### PR TITLE
Eliminate curl_write_callback warning

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -22,8 +22,9 @@
 #define CONST_CSTR_STRING(x) CSTR_STRING(x)
 #endif
 
-size_t write_string(void * ptr, size_t size, size_t nmemb, Obj buf)
+size_t write_string(char * ptr, size_t size, size_t nmemb, void * outstream)
 {
+    Obj buf = (Obj)outstream;
     UInt len = GET_LEN_STRING(buf);
     UInt newlen = len + size * nmemb;
     GROW_STRING(buf, newlen);


### PR DESCRIPTION
While building version 2.4.1 on a Fedora 42 machine, I saw this warning in the build log:
```
src/curl.c: In function ‘FuncCURL_REQUEST’:
src/curl.c:84:9: warning: call to ‘_curl_easy_setopt_err_write_callback’ declared with attribute warning: curl_easy_setopt expects a curl_write_callback argument [-Wattribute-warning]
   84 |         curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_string);
      |         ^
```

This patch changes the parameter list of `write_string` to match the definition of `curl_write_callback`.  I think the warning is relatively recent, but the current definition of `curl_write_callback` was introduced in curl 7.7.3, which was released 7 May 2001.