### PR TITLE
Replace compiled.h by gap_all.h

### DIFF
--- a/src/curl.c
+++ b/src/curl.c
@@ -2,7 +2,7 @@
 // curlInterface: Simple Web Access
 //
 
-#include "compiled.h" // GAP headers
+#include "gap_all.h" // GAP headers
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
No functional change for this package but makes it future-proof.
