### PR TITLE
Update `PackageInfo.g` and CI suite

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,40 +19,33 @@ concurrency:
 jobs:
   # The CI test job
   test:
-    name: ${{ matrix.gap-branch }} ${{ matrix.os }}
+    name: ${{ matrix.gap-version }} ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        gap-branch:
-          - master
-          - stable-4.15
-          - stable-4.14
-          - stable-4.13
-          - stable-4.12
+        gap-version:
+          - 'devel'
+          - '4.15'
+          - '4.14'
+          - '4.13'
+          - '4.12'
         os: [ubuntu-latest]
         include:
-          - gap-branch: master
+          - gap-version: 'devel'
             os: macos-latest
 
     steps:
       - uses: actions/checkout@v6
-      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/setup-gap@v3
         with:
-          GAPBRANCH: ${{ matrix.gap-branch }}
-      - name: 'Install additional dependencies'
-        run: |
-          if [ "$RUNNER_OS" == "macOS" ]; then
-            brew install curl
-          else
-            sudo apt-get install libcurl4-openssl-dev
-          fi
-      - uses: gap-actions/build-pkg@v1
-      - uses: gap-actions/run-pkg-tests@v3
-      - uses: gap-actions/run-pkg-tests@v3
+          gap-version: ${{ matrix.gap-version }}
+      - uses: gap-actions/build-pkg@v3
+      - uses: gap-actions/run-pkg-tests@v4
+      - uses: gap-actions/run-pkg-tests@v4
         with:
-          only-needed: true
-      - uses: gap-actions/process-coverage@v2
-      - uses: codecov/codecov-action@v5
+          mode: onlyneeded
+      - uses: gap-actions/process-coverage@v3
+      - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -110,7 +110,7 @@ Dependencies := rec(
   SuggestedOtherPackages := [ ],
   NeededSystemPackages := rec(
     Ubuntu   := [["libcurl4-gnutls-dev"]],
-    Homebrew := [["curl"]]
+    Homebrew := [["curl"]],
   ),
   ExternalConditions := [ ],
 ),

--- a/PackageInfo.g
+++ b/PackageInfo.g
@@ -108,6 +108,10 @@ Dependencies := rec(
   GAP := ">= 4.12",
   NeededOtherPackages := [ [ "GAPDoc", ">= 1.5" ] ],
   SuggestedOtherPackages := [ ],
+  NeededSystemPackages := rec(
+    Ubuntu   := [["libcurl4-gnutls-dev"]],
+    Homebrew := [["curl"]]
+  ),
   ExternalConditions := [ ],
 ),
 


### PR DESCRIPTION
This PR updates all actions used in the CI workflow to the latest version, and makes use of the new `Dependencies.NeededSystemPackages` field in `PackageInfo.g` to simplify the CI workflow(s).
  
Remarks:
- The `Dependencies.ExternalConditions` is empty. Since this package relies on external software, it probably shouldn't be.
- I used `libcurl4-gnutls-dev` like in this package's documentation, but the package distribution currently uses `libcurl4-openssl-dev`.