### PR TITLE
Switch tests back to httpbin.org

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,8 @@
 This file describes changes in the curlInterface package.
 
+Next
+  - Switch tests and examples from httpbun.com to httpbin.org
+
 2.4.4 (2026-07-13)
   - Remove dependency on GAPDoc
 

--- a/gap/curl.gd
+++ b/gap/curl.gd
@@ -75,7 +75,7 @@ DeclareGlobalFunction("DownloadURL");
 #!   <Ref Func="CurlRequest"/>.
 #!
 #! @BeginExample
-#! gap> r := PostToURL("httpbun.com/post", "animal=tiger");;
+#! gap> r := PostToURL("https://httpbin.org/post", "animal=tiger");;
 #! gap> r.success;
 #! true
 #! gap> r.result{[51..100]};
@@ -160,7 +160,7 @@ DeclareGlobalFunction("DeleteURL");
 #! >                     "",
 #! >                     rec(verifyCert := false));
 #! rec( result := "", success := true )
-#! gap> r := CurlRequest("httpbun.com/post", "POST", "animal=tiger");;
+#! gap> r := CurlRequest("https://httpbin.org/post", "POST", "animal=tiger");;
 #! gap> r.success;
 #! true
 #! gap> r.result{[51..100]};

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -68,7 +68,7 @@ gap> PositionSublist(r.error, "404") <> fail;
 true
 
 # Check successful POST requests
-gap> r := PostToURL("httpbun.com/post", "field1=true&field2=17");;
+gap> r := PostToURL("https://httpbin.org/post", "field1=true&field2=17");;
 gap> SortedList(RecNames(r));
 [ "result", "success" ]
 gap> r.success;
@@ -81,7 +81,7 @@ gap> PositionSublist(r.result, "field3") <> fail;
 false
 
 # Check POST on a string with null characters
-gap> r := PostToURL("httpbun.com/post", "field1=my\000first\000field");;
+gap> r := PostToURL("https://httpbin.org/post", "field1=my\000first\000field");;
 gap> SortedList(RecNames(r));
 [ "result", "success" ]
 gap> r.success;
@@ -127,7 +127,7 @@ true
 gap> post_string := List("animal=tiger&material=cotton", letter -> letter);;
 gap> IsStringRep(post_string);
 false
-gap> r := PostToURL("httpbun.com/post", post_string, rec(verifyCert := true));;
+gap> r := PostToURL("https://httpbin.org/post", post_string, rec(verifyCert := true));;
 gap> r.success;
 true
 gap> PositionSublist(r.result, "\"animal\": \"tiger\"") <> fail;
@@ -163,17 +163,17 @@ gap> PositionSublist(r.result, "405 ") <> fail;
 true
 gap> PositionSublist(r.result, "tiger") <> fail;
 false
-gap> r := DeleteURL("httpbun.com/delete");;
+gap> r := DeleteURL("https://httpbin.org/delete");;
 gap> r.success;
 true
 gap> PositionSublist(r.result, "405 ") <> fail;
 false
 
 # Check verbose requests don't break anything (we can't catch the output here)
-gap> r := DownloadURL("httpbun.com/get", rec(verbose := true));;
+gap> r := DownloadURL("https://httpbin.org/get", rec(verbose := true));;
 gap> r.success;
 true
-gap> PositionSublist(r.result, "httpbun") <> fail;
+gap> PositionSublist(r.result, "httpbin") <> fail;
 true
 
 #gap> PositionSublist(r.result, "404 ") <> fail;

--- a/tst/errors.tst
+++ b/tst/errors.tst
@@ -25,7 +25,7 @@ gap> CurlRequest("www.google.com", 637, "hello", rec(verifyCert := true));
 Error, CurlRequest: <type> must be a string
 
 # post_string not a string
-gap> PostToURL("httpbun.com/post", 17);
+gap> PostToURL("https://httpbin.org/post", 17);
 Error, CurlRequest: <out_string> must be a string
 
 # invalid verifyCert


### PR DESCRIPTION
Unfortunately httpbun.com has been having reliability issues
recently, so let's switch back to httpbin.org for now.

Also Use explicit HTTPS URLs for the currently available,
response-compatible HTTP test service.

Co-authored-by: Codex <codex@openai.com>
