### PR TITLE
Prefer Homebrew libcurl on macOS

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -2,6 +2,7 @@ This file describes changes in the curlInterface package.
 
 Next
   - Make HTTP tests hermetic with a local IO-backed server
+  - Prefer a Homebrew libcurl installation on macOS when available
 
 2.4.4 (2026-07-13)
   - Remove dependency on GAPDoc

--- a/configure.ac
+++ b/configure.ac
@@ -30,7 +30,27 @@ FIND_GAP
 dnl ##
 dnl ## Check for libcurl
 dnl ##
-LIBCURL_CHECK_CONFIG([yes],[],[],[AC_MSG_ERROR([libcurl development files required])])
+libcurl_default=yes
+
+dnl ## on macOS with Homebrew, check if it has libcurl installed and if so,
+dnl ## prefer that over the ancient version bundled with macOS
+AS_IF([test "x`uname -s 2>/dev/null`" = xDarwin], [
+  AS_IF([command -v brew >/dev/null 2>&1], [
+    libcurl_homebrew_prefix=`brew --prefix curl 2>/dev/null`
+    AS_IF([test -x "$libcurl_homebrew_prefix/bin/curl-config"], [
+      libcurl_default=$libcurl_homebrew_prefix
+    ])
+  ])
+])
+
+LIBCURL_CHECK_CONFIG([$libcurl_default],[],[
+  AS_IF([test "x$libcurl_default" != xyes &&
+         test -z "$with_libcurl"], [
+    AC_MSG_NOTICE([using Homebrew libcurl from $libcurl_default])
+  ])
+],[
+  AC_MSG_ERROR([libcurl development files required])
+])
 
 dnl ##
 dnl ## Output everything

--- a/m4/libcurl.m4
+++ b/m4/libcurl.m4
@@ -95,9 +95,9 @@ AC_DEFUN([LIBCURL_CHECK_CONFIG],
     _libcurl_try_link=yes
 
     if test -d "$_libcurl_with"; then
-      LIBCURL_CPPFLAGS="-I$withval/include"
-      _libcurl_ldflags="-L$withval/lib"
-      AC_PATH_PROG([_libcurl_config],[curl-config],[],["$withval/bin"])
+      LIBCURL_CPPFLAGS="-I$_libcurl_with/include"
+      _libcurl_ldflags="-L$_libcurl_with/lib"
+      AC_PATH_PROG([_libcurl_config],[curl-config],[],["$_libcurl_with/bin"])
     else
       AC_PATH_PROG([_libcurl_config],[curl-config],[],[$PATH])
     fi


### PR DESCRIPTION
Use the macro's default action to select keg-only Homebrew curl while
preserving explicit configuration and system fallback behavior.

Co-authored-by: Codex <codex@openai.com>
